### PR TITLE
Make all warnings suppressible

### DIFF
--- a/time_in_each_roi.py
+++ b/time_in_each_roi.py
@@ -2,6 +2,7 @@ import numpy as np
 from collections import namedtuple
 from scipy.spatial import distance
 import pandas as pd
+import warnings
 
 """
     Functions to extract time spent by the mouse in each of a list of user defined ROIS 
@@ -138,7 +139,7 @@ def get_roi_at_each_frame(bp_data, rois, check_inroi):
                 cleaned_rois.append(roi)
         return cleaned_rois
     else:
-        raise ValueError("Warning: you've set check_inroi=False, so data reflect which ROI is closest even if tracked point is not in any given ROI.")
+        warnings.warn("Warning: you've set check_inroi=False, so data reflect which ROI is closest even if tracked point is not in any given ROI.")
         return roi_at_each_frame
 
 

--- a/time_in_each_roi.py
+++ b/time_in_each_roi.py
@@ -138,7 +138,7 @@ def get_roi_at_each_frame(bp_data, rois, check_inroi):
                 cleaned_rois.append(roi)
         return cleaned_rois
     else:
-        print("Warning: you've set check_inroi=False, so data reflect which ROI is closest even if tracked point is not in any given ROI.")
+        raise ValueError("Warning: you've set check_inroi=False, so data reflect which ROI is closest even if tracked point is not in any given ROI.")
         return roi_at_each_frame
 
 


### PR DESCRIPTION
@FedeClaudi Thank you for the great program!

I noticed that in line 141 you used print() which forces the program to print the warning statement every time it runs, unlike something like `warnings.warn()`. I updated this so that one can silence all warning messages when they need to (e.g., `warnings.filterwarnings("ignore")`).